### PR TITLE
Fix bug with nested children of other children

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -525,12 +525,13 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 			}
 
 			// rewrite any item with parentItem key to be nested in its parent
+			const removedChildren = new Map<string, ZoteroItem>();
 			for (const [key, item] of map.items) {
 				if (!item.children) {
 					item.children = []
 				}
 				if (item.parentItem) {
-					const parent = map.items.get(item.parentItem)
+					const parent = map.items.get(item.parentItem) ?? removedChildren.get(item.parentItem)
 					if (!parent) {
 						continue
 					}
@@ -538,6 +539,7 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 						parent.children = []
 					}
 					parent.children.push(item)
+					removedChildren.set(item.key, item)
 					map.items.delete(key)
 				}
 				if (item.collections) {


### PR DESCRIPTION
 Hi, there was a bug when loading the items and their child-parent relationships.
 The bug occured when the parent was itself a child of another item, for example an attachment.
 When a child (annotation) of that parent (attachment) is behind the parent in the map,
 the parent was already removed from the map and the child could not find its parent.
 I don't know if this is the best solution, but I added the removed items to a list and
 added a fallback loop to check if the parent is in the list of removed items.

 A consequence of that was that not all annotations were associated with an attachment.