### PR TITLE
Suggested Fix: convert <img> tags to markdown properly

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -55,7 +55,6 @@ type ZoteroRemoteLibrary = {
 
 interface ZoteroSyncClientSettings {
 	api_key: string;
-	user_id: string;
 	sync_on_startup: boolean;
 	sync_on_interval: boolean;
 	sync_interval: number;
@@ -65,7 +64,6 @@ interface ZoteroSyncClientSettings {
 
 const DEFAULT_SETTINGS: ZoteroSyncClientSettings = {
 	api_key: '',
-	user_id: '',
 	sync_on_startup: true,
 	sync_on_interval: false,
 	sync_interval: 0,
@@ -495,7 +493,7 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 				collections: new Map(data.collections.map((c: ZoteroCollectionItem) => [c.key, c])),
 				items: new Map(data.items.map((i: ZoteroItem) => {
 					if (i.itemType.toLowerCase() === 'note' && i.note) {
-						const modified_note = this.addSrcAttributeToImageTagsIfMissing(i.note, this.settings.user_id, this.settings.api_key);
+						const modified_note = this.addSrcAttributeToImageTagsIfMissing(i.note, this.client.userID.toString(), this.settings.api_key);
 						i.note_markdown = htmlToMarkdown(modified_note);
 					}
 					return [i.key, i]

--- a/main.ts
+++ b/main.ts
@@ -10,6 +10,7 @@ import {
 	Notice,
 	debounce,
 	addIcon,
+	requestUrl,
 	prepareFuzzySearch,
 	TAbstractFile
 } from 'obsidian';
@@ -226,7 +227,7 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 		}
 	}
 
-	async sync(debounce_seconds: number = 0) {
+	async sync(debounce_seconds = 0) {
 		// check if sync has been completed recently
 		if (this.last_sync && debounce_seconds > 0) {
 			const now = new Date()
@@ -237,10 +238,10 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 			}
 		}
 
-		if (true) { // note: you may want to disable the sync during
-			//       development to avoid hitting API limits
-			await this.syncWithZotero()
-		}
+		// note: you may want to disable the sync during
+		//       development to avoid hitting API limits
+		await this.syncWithZotero()
+
 
 		await this.applyAllUpdates()
 
@@ -468,6 +469,77 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 		return `[🇿](zotero://select${domain}/${kind}/${element.key})`
 	}
 
+	sanitizeZoteroKey(key: string | null): string | null {
+		if (!key) {
+			return null;
+		}
+		// 8 alphanumeric characters
+		const zoteroKeyPattern = /^[A-Za-z0-9]{8}$/;
+		const trimmedKey = key.trim();
+		if (zoteroKeyPattern.test(trimmedKey)) {
+			return trimmedKey;
+		}
+		return null;
+	}
+
+	findHeader(headers: Record<string, string>, headerName: string, defaultValue = ''): string {
+		const key = Object.keys(headers).find(
+			key => key.toLowerCase() === headerName.toLowerCase()
+		);
+		return key ? headers[key] : defaultValue;
+	}
+
+	async fetchImageAsBase64(url: string): Promise<string> {
+		try {
+			const response = await requestUrl({
+				'url': url,
+				headers: {
+					'Accept': 'image/*',
+					'Authorization': `Bearer ${this.settings.api_key}`
+				}
+			});
+
+			if (!response.status || response.status !== 200) {
+				throw new Error(`Image fetch failed: ${response.status}`);
+			}
+
+			const arrayBuffer = await response.arrayBuffer;
+			const bytes = new Uint8Array(arrayBuffer);
+			let binary = '';
+			for (let i = 0; i < bytes.length; i++) {
+				binary += String.fromCharCode(bytes[i]);
+			}
+
+			const base64 = window.btoa(binary);
+			const contentType = this.findHeader(response.headers, 'content-type', 'image/jpeg');
+			return `data:${contentType};base64,${base64}`;
+		} catch (error) {
+			console.error('Failed to fetch image:', error);
+			return '';
+		}
+	}
+
+	async transformAttachmentImgTags(html: string): Promise<string> {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(html, "text/html");
+		const imgElements = doc.querySelectorAll("img[data-attachment-key]");
+
+		const promises = Array.from(imgElements).map(async (img) => {
+			const attKey = this.sanitizeZoteroKey(img.getAttribute("data-attachment-key"));
+			if (attKey) {
+				const fileUrl = `https://api.zotero.org/users/${this.client.userID}/items/${attKey}/file`;
+				const base64Data = await this.fetchImageAsBase64(fileUrl);
+				if (base64Data) {
+					img.setAttribute("src", base64Data);
+				}
+			}
+		});
+
+		await Promise.all(promises);
+
+		return doc.body.innerHTML;
+	}
+
 	async readLibrary(library: string): Promise<{
 		collections: Map<string, ZoteroCollectionItem>;
 		items: Map<string, ZoteroItem>;
@@ -493,14 +565,23 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 				collections: new Map(data.collections.map((c: ZoteroCollectionItem) => [c.key, c])),
 				items: new Map(data.items.map((i: ZoteroItem) => {
 					if (i.itemType.toLowerCase() === 'note' && i.note) {
-						const modified_note = this.transformImgTags(i.note, this.client.userID.toString(), this.settings.api_key);
-						i.note_markdown = htmlToMarkdown(modified_note);
+						// convert without images
+						i.note_markdown = htmlToMarkdown(i.note);
 					}
 					return [i.key, i]
 				}))
 			}
+
+			// fetch attachments
+			for (const item of map.items.values()) {
+				if (item.itemType.toLowerCase() === 'note' && item.note) {
+					const transformedHtml = await this.transformAttachmentImgTags(item.note);
+					item.note_markdown = htmlToMarkdown(transformedHtml);
+				}
+			}
+
 			// rewrite any collection with parentCollection key to be nested in its parent
-			for (const [key, collection] of map.collections) {
+			for (const collection of map.collections.values()) {
 				if (!collection.itemType) {
 					collection.itemType = "collection"
 				}
@@ -585,7 +666,10 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 		}
 	}
 
-	async writeStatus(library: string, status: any) {
+	async writeStatus(library: string, status: {
+		collections: Map<string, ZoteroNoteStatus>;
+		items: Map<string, ZoteroNoteStatus>;
+	}) {
 		// write library status to store
 		try {
 			const filePath = this.getPluginPath("store", `${encodeURIComponent(library)}.status.json`)
@@ -617,21 +701,6 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 			await this.clearStatus(library.prefix)
 		}
 		new Notice(`Zotero Sync: Cleared cache`)
-	}
-
-	transformImgTags(html: string, userID: string, apiKey: string): string {
-		const parser = new DOMParser();
-		const doc = parser.parseFromString(html, "text/html");
-		const imgElements = doc.querySelectorAll("img[data-attachment-key]");
-		imgElements.forEach((img) => {
-			const attKey = img.getAttribute("data-attachment-key");
-			if (attKey) {
-				const fileUrl = `https://api.zotero.org/users/${userID}/items/${attKey}/file?key=${apiKey}`;
-				img.setAttribute("src", fileUrl);
-			}
-		});
-
-		return doc.body.innerHTML;
 	}
 
 }
@@ -819,7 +888,7 @@ class ClientSettingTab extends PluginSettingTab {
 				const data = await this.plugin.readLibrary(library.prefix);
 
 				// parse file names
-				let fileNames = [];
+				const fileNames = [];
 				for (const item of data.collections.values()) {
 					try {
 						const fp = this.plugin.generateNoteFilePath(item, data.collections, data.items, library, fpCodeEditor.value);

--- a/main.ts
+++ b/main.ts
@@ -493,7 +493,7 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 				collections: new Map(data.collections.map((c: ZoteroCollectionItem) => [c.key, c])),
 				items: new Map(data.items.map((i: ZoteroItem) => {
 					if (i.itemType.toLowerCase() === 'note' && i.note) {
-						const modified_note = this.addSrcAttributeToImageTagsIfMissing(i.note, this.client.userID.toString(), this.settings.api_key);
+						const modified_note = this.transformImgTags(i.note, this.client.userID.toString(), this.settings.api_key);
 						i.note_markdown = htmlToMarkdown(modified_note);
 					}
 					return [i.key, i]
@@ -619,33 +619,19 @@ export default class ZoteroSyncClientPlugin extends Plugin {
 		new Notice(`Zotero Sync: Cleared cache`)
 	}
 
-	addSrcAttributeToImageTagsIfMissing(html: string, userID?: string, apiKey?: string): string {
-		if (!userID || !apiKey) return html;
-		// Regular expression to match img tags with a data-attachment-key attribute
-		const imgRe = /<img([^>]*\sdata-attachment-key=(['"])([^'"]+)\2[^>]*)>/gi;
-		/*
-		- `<img`: Matches the starting part of an `<img>` tag.
-		- `([^>]*`: Matches any characters that are not a closing bracket (`>`), allowing for other attributes before `data-attachment-key`.
-		- `\sdata-attachment-key=`: Matches the exact string ` data-attachment-key=` with a preceding whitespace.
-		- `(['"])`: Captures the quote character (either single or double) used for the attribute value.
-		- `([^'"]+)`: Captures the value of the `data-attachment-key` attribute, which can be any characters except for the matching quote character.
-		- `\2`: Refers back to the captured quote character to ensure the string is properly closed.
-		- `[^>]*)`: Matches any additional characters that are not a closing bracket, allowing for more attributes in the `<img>` tag.
-		- `>`: Matches the closing bracket of the `<img>` tag.
-		- `gi`: The `g` flag indicates a global search (find all matches), and the `i` flag makes the search case-insensitive. 
-		*/
-		return html.replace(imgRe, (match, attrs, quote, attKey) => {
-			// Construct the file URL using the user ID and attachment key
-			const fileUrl = `https://api.zotero.org/users/${userID}/items/${attKey}/file?key=${apiKey}`;
-			// If there’s already a src, we replace it; otherwise we append it at the end
-			if (/src=/i.test(attrs)) {
-				// Replace the existing src attribute with the new file URL
-				return match.replace(/src=(['"])[^'"]*\1/, `src="${fileUrl}"`);
-			} else {
-				// Add the new src attribute to the img tag
-				return `<img${attrs} src="${fileUrl}">`;
+	transformImgTags(html: string, userID: string, apiKey: string): string {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(html, "text/html");
+		const imgElements = doc.querySelectorAll("img[data-attachment-key]");
+		imgElements.forEach((img) => {
+			const attKey = img.getAttribute("data-attachment-key");
+			if (attKey) {
+				const fileUrl = `https://api.zotero.org/users/${userID}/items/${attKey}/file?key=${apiKey}`;
+				img.setAttribute("src", fileUrl);
 			}
 		});
+
+		return doc.body.innerHTML;
 	}
 
 }


### PR DESCRIPTION
The issue happens when importing items from Zotero and iterating over notes, as shown in the following snippet:
```
if (data.children) {
	const notes = data.children.filter(
		c => c.itemType.toLowerCase() == 'note'
	);
	notes.forEach(c => {
		n += c.note_markdown + '\n\n';
	});
}
```

I encountered an issue where the `note_markdown` drops `img` tags from the `c.note` object. This happens because the `htmlToMarkdown` function fails to convert `img` tags to markdown when the image lacks a `src` attribute.

To address this, I added a function that retrieves `img` tags and populates the `src` attribute using the user's Zotero `userId` and `apikey` + `itemKey`. This enhancement ensures that all images are properly converted and included in the markdown output.

I couldn't compile the project, as I couldn't set up Node within the short time I have. But to make sure the suggested fix works, I altered the plugin source code in Obsidian, and it worked. I can spend more time on this if you find issues with the fix.